### PR TITLE
feat(certificate): add certificate revocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The API and implementation were inspired by [acme2][], [acme-micro][], and [lego
 ### Missing features
 
 - [ ] Certificate renewal
-- [ ] Certificate revocation
+- [x] Certificate revocation
 - [ ] [TLS-ALPN-01][] challenge implementation
 - [ ] Certificate bundling
 - [ ] [External account binding][]

--- a/src/account.rs
+++ b/src/account.rs
@@ -3,13 +3,14 @@ use crate::{
     certificate::CertificateBuilder,
     error::Result,
     responses::{self, AccountStatus, RevocationReason},
-    Certificate, Error,
+    Error,
 };
 use base64::engine::{general_purpose::URL_SAFE_NO_PAD as BASE64, Engine};
 use openssl::{
     ec::{EcGroup, EcKey},
     nid::Nid,
     pkey::{PKey, Private},
+    x509::X509,
 };
 
 pub struct NoPrivateKey;
@@ -147,7 +148,7 @@ impl Account {
     }
 
     /// Revoke a certificate
-    pub async fn revoke_certificate(&self, certificate: &Certificate) -> Result<()> {
+    pub async fn revoke_certificate(&self, certificate: &X509) -> Result<()> {
         let der = BASE64.encode(certificate.to_der()?);
         self.api
             .revoke_certificate(der, None, &self.private_key, Some(&self.id))
@@ -157,7 +158,7 @@ impl Account {
     /// Revoke a certificate with a reason.
     pub async fn revoke_certificate_with_reason(
         &self,
-        certificate: &Certificate,
+        certificate: &X509,
         reason: RevocationReason,
     ) -> Result<()> {
         let der = BASE64.encode(certificate.to_der()?);

--- a/src/api.rs
+++ b/src/api.rs
@@ -245,6 +245,30 @@ impl Api {
         Ok(certificate)
     }
 
+    /// Revoke a certificate
+    ///
+    /// If the `account_key` is not `None`, the `private_key` must be that of the account. Otherwise,
+    /// it must be the certificate's private key.
+    pub async fn revoke_certificate(
+        &self,
+        certificate: String,
+        reason: Option<responses::RevocationReason>,
+        private_key: &PKey<Private>,
+        account_id: Option<&str>,
+    ) -> Result<()> {
+        self.request_json(
+            &self.0.urls.revoke_cert,
+            &responses::RevocationRequest {
+                certificate,
+                reason,
+            },
+            private_key,
+            account_id,
+        )
+        .await?;
+        Ok(())
+    }
+
     /// Wait until the fetched resource meets a condition or the maximum attempts are exceeded.
     #[allow(clippy::too_many_arguments)]
     pub async fn wait_until<'a, F, P, T, Fut>(

--- a/src/certificate.rs
+++ b/src/certificate.rs
@@ -153,6 +153,16 @@ impl Certificate {
         }
         Ok(result)
     }
+
+    /// Get a reference to the underlying [`openssl::x509::X509`] instance for the certificate.
+    pub fn x509(&self) -> &X509 {
+        self.chain.first().unwrap()
+    }
+
+    /// Get a reference to the full [`openssl::x509::X509`] chain for the certificate.
+    pub fn x509_chain(&self) -> &[X509] {
+        self.chain.as_slice()
+    }
 }
 
 #[cfg(test)]
@@ -346,7 +356,10 @@ mod tests {
             .await
             .unwrap();
 
-        account.revoke_certificate(&certificate).await.unwrap();
+        account
+            .revoke_certificate(certificate.x509())
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
@@ -362,7 +375,7 @@ mod tests {
             .unwrap();
 
         account
-            .revoke_certificate_with_reason(&certificate, RevocationReason::Superseded)
+            .revoke_certificate_with_reason(certificate.x509(), RevocationReason::Superseded)
             .await
             .unwrap();
     }

--- a/src/directory.rs
+++ b/src/directory.rs
@@ -100,6 +100,11 @@ impl Directory {
     pub fn meta(&self) -> &DirectoryMeta {
         self.0.meta()
     }
+
+    /// Get a reference to the API, only for use by actions that don't depend on an account.
+    pub(crate) fn api(&self) -> &Api {
+        &self.0
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Adds certificate revocation from an `Account` and from an issued `Certificate`. Certificates can be revoked with or without a reason (assuming the CA allows it).