### PR TITLE
feat(certificate): add certificate renewal

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The API and implementation were inspired by [acme2][], [acme-micro][], and [lego
 - ACME v2 ([RFC 8555][])
 - Register with CA
 - Obtain certificates
+- Renew certificates
 - Revoke certificates
 - Robust implementation of ACME challenges
   - [HTTP][] (http-01)
@@ -21,7 +22,6 @@ The API and implementation were inspired by [acme2][], [acme-micro][], and [lego
 
 ### Missing features
 
-- [ ] Certificate renewal
 - [ ] [TLS-ALPN-01][] challenge implementation
 - [ ] Certificate bundling
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ pub(crate) const USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("C
 
 pub use account::{Account, AccountBuilder};
 pub use api::responses;
-pub use certificate::{Certificate, CertificateBuilder};
+pub use certificate::{Certificate, CertificateBuilder, Format};
 pub use directory::{
     Directory, DirectoryBuilder, LETS_ENCRYPT_PRODUCTION_URL, LETS_ENCRYPT_STAGING_URL,
 };


### PR DESCRIPTION
Allows renewing certificates with `Account::renew_certificate`.

This also adds the ability to load certificates from PEM- and DER-encoded certificate chains and private keys with `Certificate::from_chain_and_private_key`. There is also a less checked version `Certificate::from_raw_chain_and_private_key` that can be used when the private key and certificate chain have already been parsed.