### PR TITLE
ci(test): ensure examples build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,4 +46,14 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo build --features http-01,dns-01 --examples
+      - run: pip install yq
+
+      - name: Build examples
+        run: |
+          for example in $(tomlq -r '.example[] | "\(.name):\(.["required-features"] | join(","))"' Cargo.toml); do
+            name=$(echo $example | awk -F: '{ print $1 }')
+            features=$(echo $example | awk -F: '{ print $2 }')
+
+            echo "Building example $name"
+            cargo build --example $name --features $features
+          done


### PR DESCRIPTION
Add building all the examples in CI by parsing `Cargo.toml` for their names and required features. We parse `Cargo.toml` to make it more flexible as new examples are added.